### PR TITLE
Change accordian default to closed not open

### DIFF
--- a/Resources/views/customer_fields_view.blade.php
+++ b/Resources/views/customer_fields_view.blade.php
@@ -8,7 +8,7 @@
                 </a>
             </div>
         </div>
-        <div id="collapseOne" class="freemius-panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne">
+        <div id="collapseOne" class="freemius-panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
             <div class="freemius-panel-body">
                 <ul class="freemius-list">
                     <li>


### PR DESCRIPTION
Very helpful when viewing/editing customers and it displays at the top when there's no sidebar.